### PR TITLE
Fix: Remove trailing asterisks from RDS version numbers

### DIFF
--- a/aws_generated_data/commands/rds_eol.py
+++ b/aws_generated_data/commands/rds_eol.py
@@ -29,7 +29,6 @@ class RdsItem(BaseModel):
     eol: date
 
     def __init__(self, **data: Any):
-    # Clean the version by removing any trailing asterisks
         if 'version' in data:
             data['version'] = data['version'].rstrip('*')
         super().__init__(**data)

--- a/aws_generated_data/commands/rds_eol.py
+++ b/aws_generated_data/commands/rds_eol.py
@@ -28,6 +28,12 @@ class RdsItem(BaseModel):
     version: str
     eol: date
 
+    def __init__(self, **data: Any):
+    # Clean the version by removing any trailing asterisks
+        if 'version' in data:
+            data['version'] = data['version'].rstrip('*')
+        super().__init__(**data)
+
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, RdsItem):
             return False

--- a/aws_generated_data/commands/rds_eol.py
+++ b/aws_generated_data/commands/rds_eol.py
@@ -29,8 +29,8 @@ class RdsItem(BaseModel):
     eol: date
 
     def __init__(self, **data: Any):
-        if 'version' in data:
-            data['version'] = data['version'].rstrip('*')
+        if "version" in data:
+            data["version"] = data["version"].rstrip("*")
         super().__init__(**data)
 
     def __lt__(self, other: Any) -> bool:

--- a/tests/test_rds_eol.py
+++ b/tests/test_rds_eol.py
@@ -100,6 +100,19 @@ def test_get_rds_eol_data(
     ]
     m.assert_called_once_with("data")
 
+def test_get_rds_eol_data_with_asterisk(
+    mocker: MockerFixture, requests_mock: requests_mock.Mocker
+) -> None:
+    m = mocker.patch(
+        "aws_generated_data.commands.rds_eol.parse_aws_release_calendar",
+        autospec=True,
+        return_value=[("1.2.3*", dt(2021, 1, 1))],
+    )
+    requests_mock.get("https://example.com", text="data")
+    assert get_rds_eol_data(Engine("mysql:https://example.com")) == [
+        RdsItem(engine="mysql", version="1.2.3", eol=date(2021, 1, 1))
+    ]
+    m.assert_called_once_with("data")
 
 @pytest.mark.parametrize(
     "date_str, expected",


### PR DESCRIPTION
Fixes an issue where RDS version numbers with trailing asterisks would not be processed correctly by the aws-resource-exporter.