### PR TITLE
:bug: skip unparseable/invalid dates

### DIFF
--- a/aws_generated_data/commands/msk_eol.py
+++ b/aws_generated_data/commands/msk_eol.py
@@ -39,7 +39,11 @@ def parse_msk_release_calendar(page: str) -> list[CalItem]:
             date_str = cols[2].text.strip()
             if date_str == "--":
                 continue
-            items.append((cols[0].text.strip(), parse_date(date_str)))
+            try:
+                items.append((cols[0].text.strip(), parse_date(date_str)))
+            except ValueError:
+                # skip invalid dates
+                pass
 
     return items
 

--- a/aws_generated_data/commands/rds_eol.py
+++ b/aws_generated_data/commands/rds_eol.py
@@ -67,7 +67,11 @@ def parse_aws_release_calendar(page: str) -> list[CalItem]:
     for row in version_table.find_all("tr"):  # type: ignore
         cols = row.find_all("td")
         if len(cols) == 4:  # noqa: PLR2004
-            items.append((cols[0].text.strip(), parse_date(cols[3].text.strip())))
+            try:
+                items.append((cols[0].text.strip(), parse_date(cols[3].text.strip())))
+            except ValueError:
+                # skip invalid dates
+                pass
 
     return items
 


### PR DESCRIPTION
dates like `To be announced` aren't valid. skip such date strings