### PR TITLE
:green_heart: ci-run: fix permission error on rhel8 jenkins nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ci-run: build-test-image
 
 	# Run agd rds-eol
 	docker run --rm \
-		-v '$(PWD)/output':/output \
+		-v '$(PWD)/output':/output:z \
 		-e AGD_RDS_EOL_ENGINES='$(AGD_RDS_EOL_ENGINES)' \
 		-e AGD_RDS_EOL_OUTPUT='/output/$(AGD_RDS_EOL_OUTPUT)' \
 		-e AGD_MSK_RELEASE_CALENDAR_URL='$(AGD_MSK_RELEASE_CALENDAR_URL)' \


### PR DESCRIPTION
RHEL8 has Selinux enabled, and this needs an additional volume mount [option](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label)