### PR TITLE
:fire: avoid AWS captcha check

### DIFF
--- a/aws_generated_data/commands/msk_eol.py
+++ b/aws_generated_data/commands/msk_eol.py
@@ -7,13 +7,13 @@ from datetime import (
 from pathlib import Path
 from typing import Annotated
 
-import requests
 import typer
 from bs4 import BeautifulSoup
 
 from aws_generated_data.utils import (
     VersionItem,
     filter_items,
+    http_get,
     parse_date,
     read_output_file,
     write_output_file,
@@ -49,10 +49,10 @@ def parse_msk_release_calendar(page: str) -> list[CalItem]:
 
 
 def get_msk_eol_data(msk_release_calendar_url: str) -> list[VersionItem]:
-    version_page = requests.get(msk_release_calendar_url)
+    version_page = http_get(msk_release_calendar_url)
     return [
         VersionItem(version=version, eol=d.date())
-        for version, d in parse_msk_release_calendar(version_page.text)
+        for version, d in parse_msk_release_calendar(version_page)
     ]
 
 

--- a/aws_generated_data/commands/rds_eol.py
+++ b/aws_generated_data/commands/rds_eol.py
@@ -7,13 +7,13 @@ from datetime import (
 from pathlib import Path
 from typing import Annotated, Any
 
-import requests
 import typer
 from bs4 import BeautifulSoup
 
 from aws_generated_data.utils import (
     VersionItem,
     filter_items,
+    http_get,
     parse_date,
     read_output_file,
     write_output_file,
@@ -76,10 +76,10 @@ def parse_aws_release_calendar(page: str) -> list[CalItem]:
 
 
 def get_rds_eol_data(engine: Engine) -> list[RdsItem]:
-    version_page = requests.get(engine.url)
+    version_page = http_get(engine.url)
     return [
         RdsItem(engine=engine.name, version=version, eol=d.date())
-        for version, d in parse_aws_release_calendar(version_page.text)
+        for version, d in parse_aws_release_calendar(version_page)
     ]
 
 

--- a/aws_generated_data/utils.py
+++ b/aws_generated_data/utils.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Protocol, TypeVar
 
+import requests
 import yaml
 from pydantic import BaseModel, RootModel, ValidationError, field_validator
 
@@ -77,3 +78,8 @@ def write_output_file(output: Path, items: Sequence[Any]) -> None:
 def filter_items(items: Iterable[EOLType], expired_date: date) -> list[EOLType]:
     """Filter items that are not expired."""
     return [item for item in items if item.eol > expired_date]
+
+
+def http_get(url: str) -> str:
+    # AWS blocks Python requests. Use curl's user-agent to bypass the captcha check.
+    return requests.get(url, headers={"user-agent": "curl/8.6.0"}).text


### PR DESCRIPTION
AWS blocks HTTP requests from the Python requests library based on the user agent. Let's use `curl/8.6.0` instead ;) 